### PR TITLE
Added music service submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "music-service"]
+	path = music-service
+	url = https://github.com/me-next/music-service

--- a/MeNext.sln
+++ b/MeNext.sln
@@ -7,6 +7,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MeNext.iOS", "iOS\MeNext.iO
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MeNext.Droid", "Droid\MeNext.Droid.csproj", "{01AD4898-4237-42F4-902A-F439D7BE9375}"
 EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "MusicService", "music-service\MusicService\MusicService.shproj", "{2EC65026-97B2-4ACF-A489-275796F7748D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleMusicService", "music-service\SampleMusicService\SampleMusicService.csproj", "{4BF91CBC-5AD7-499D-B484-67601AEA2E08}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -53,5 +57,17 @@ Global
 		{01AD4898-4237-42F4-902A-F439D7BE9375}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 		{01AD4898-4237-42F4-902A-F439D7BE9375}.Debug|iPhone.ActiveCfg = Debug|Any CPU
 		{01AD4898-4237-42F4-902A-F439D7BE9375}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{4BF91CBC-5AD7-499D-B484-67601AEA2E08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4BF91CBC-5AD7-499D-B484-67601AEA2E08}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4BF91CBC-5AD7-499D-B484-67601AEA2E08}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4BF91CBC-5AD7-499D-B484-67601AEA2E08}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4BF91CBC-5AD7-499D-B484-67601AEA2E08}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{4BF91CBC-5AD7-499D-B484-67601AEA2E08}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{4BF91CBC-5AD7-499D-B484-67601AEA2E08}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{4BF91CBC-5AD7-499D-B484-67601AEA2E08}.Release|iPhone.Build.0 = Release|Any CPU
+		{4BF91CBC-5AD7-499D-B484-67601AEA2E08}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{4BF91CBC-5AD7-499D-B484-67601AEA2E08}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{4BF91CBC-5AD7-499D-B484-67601AEA2E08}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{4BF91CBC-5AD7-499D-B484-67601AEA2E08}.Debug|iPhone.Build.0 = Debug|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/fetchSubmodules.sh
+++ b/fetchSubmodules.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+git submodule update --init --recursive


### PR DESCRIPTION
I've added the projects MusicService and SampleMusicService as git submodules from another repo.

Would somebody please try checking out the api_interfaces branch and letting me know if those two projects are accessible (_ie_ you can see the code) from within Xamarin?

If they aren't, you may need to `cd` into the project directory and run `git submodule update --init --recursive`.

Please inform if things look like they're working.